### PR TITLE
clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: goreleaser/goreleaser-action@master
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
 


### PR DESCRIPTION
`--rm-dist` has been deprecated in favor of `--clean`
https://goreleaser.com/deprecations/#-rm-dist