### PR TITLE
goreleaser config file is outdated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ bin
 .local
 testbin
 .vscode
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,10 @@
+version: 2
+
 before:
   hooks:
     - go mod download
     - go generate ./...
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -9,20 +12,30 @@ builds:
       - linux
       - windows
       - darwin
+
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
+
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
Before changes:

```txt
$ goreleaser check
  • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
  ⨯ release failed after 0s                  error=only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
```

After changes:

```txt
$ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```
