### PR TITLE
Fix gorelease arch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,8 @@ archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`
     name_template: >-
-      {{ .ProjectName }}_
+      {{ .ProjectName }}_v
+      {{- .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,10 +14,7 @@ builds:
       - darwin
     goarch:
       - 386
-      - amd64
-      - arm
       - arm64
-      - ppc64le
 
 archives:
 - name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,10 +14,22 @@ builds:
       - darwin
     goarch:
       - 386
+      - amd64
       - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
 
 archives:
-- name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
Don't compile windows arm64 since go version is 1.16

Builds fine locally:

```sh
$ goreleaser build --snapshot --clean
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=4823b28cfd362dd4c1cdf44f02c2bfcda8052c51 branch=gorelease-trouble current_tag=v0.0.37 previous_tag=v0.0.36 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.0.37-next
  • running before hooks
    • running                                        hook=go mod download
    • running                                        hook=go generate ./...
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/slack-operator_windows_amd64_v1/slack-operator.exe
    • building                                       binary=dist/slack-operator_linux_amd64_v1/slack-operator
    • building                                       binary=dist/slack-operator_windows_386/slack-operator.exe
    • building                                       binary=dist/slack-operator_darwin_arm64/slack-operator
    • building                                       binary=dist/slack-operator_linux_386/slack-operator
    • building                                       binary=dist/slack-operator_darwin_amd64_v1/slack-operator
    • building                                       binary=dist/slack-operator_linux_arm64/slack-operator
  • writing artifacts metadata
  • build succeeded after 3s
  • thanks for using goreleaser!
```